### PR TITLE
Configurable widget when adding or clicking the widget through the settings activity

### DIFF
--- a/app/src/main/java/com/emmaguy/monzo/widget/MonzoWidgetApp.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/MonzoWidgetApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import com.emmaguy.monzo.widget.api.ApiModule
 import com.emmaguy.monzo.widget.login.LoginModule
+import com.emmaguy.monzo.widget.settings.SettingsModule
 import timber.log.Timber
 
 
@@ -11,6 +12,7 @@ class MonzoWidgetApp : Application() {
     lateinit var storageModule: StorageModule
     lateinit var apiModule: ApiModule
     lateinit var loginModule: LoginModule
+    lateinit var settingsModule: SettingsModule
 
     override fun onCreate() {
         super.onCreate()
@@ -18,6 +20,7 @@ class MonzoWidgetApp : Application() {
         storageModule = StorageModule(this)
         apiModule = ApiModule(this, storageModule)
         loginModule = LoginModule(this, storageModule, apiModule)
+        settingsModule = SettingsModule(this, storageModule)
 
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())

--- a/app/src/main/java/com/emmaguy/monzo/widget/UserStorage.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/UserStorage.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.emmaguy.monzo.widget.api.model.Balance
 import com.emmaguy.monzo.widget.api.model.Token
+import com.emmaguy.monzo.widget.settings.SettingsPresenter
 
 class UserStorage(context: Context) {
     private val KEY_REFRESH_TOKEN = "KEY_REFRESH_TOKEN"
@@ -20,6 +21,8 @@ class UserStorage(context: Context) {
 
     private val KEY_CA_CURRENCY = "KEY_CA_CURRENCY"
     private val KEY_CA_BALANCE = "KEY_CA_BALANCE"
+
+    private val KEY_ACCOUNT_TYPE = "KEY_ACCOUNT_TYPE"
 
     private val sharedPreferences: SharedPreferences = context.getSharedPreferences("user_storage", Context.MODE_PRIVATE)
 
@@ -72,6 +75,24 @@ class UserStorage(context: Context) {
         set(id) {
             sharedPreferences.edit().putString(KEY_CURRENT_ACCOUNT_ID, id).apply()
         }
+
+    fun saveAccountType(widgetId: Int?, accountType: Int) {
+        sharedPreferences
+                .edit()
+                .putInt(KEY_ACCOUNT_TYPE + widgetId, accountType)
+                .apply()
+    }
+
+    fun getAccountType(widgetId: Int): Int {
+        return sharedPreferences.getInt(KEY_ACCOUNT_TYPE + widgetId, 0)
+    }
+
+    fun removeAccountType(widgetId: Int) {
+        return sharedPreferences
+                .edit()
+                .remove(KEY_ACCOUNT_TYPE + widgetId)
+                .apply()
+    }
 
     fun saveToken(token: Token) {
         sharedPreferences

--- a/app/src/main/java/com/emmaguy/monzo/widget/balance/BalanceWidgetProvider.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/balance/BalanceWidgetProvider.kt
@@ -13,14 +13,13 @@ import android.text.style.ForegroundColorSpan
 import android.widget.RemoteViews
 import com.emmaguy.monzo.widget.MonzoWidgetApp
 import com.emmaguy.monzo.widget.R
-import com.emmaguy.monzo.widget.api.model.Balance
 import com.emmaguy.monzo.widget.common.TypefaceSpan
 import com.emmaguy.monzo.widget.common.toPx
-import com.emmaguy.monzo.widget.settings.SettingsPresenter
 import java.math.BigDecimal
 import java.util.*
 import android.app.PendingIntent
 import android.content.Intent
+import com.emmaguy.monzo.widget.api.model.AccountType
 import com.emmaguy.monzo.widget.settings.SettingsActivity
 
 
@@ -53,7 +52,7 @@ class BalanceWidgetProvider : AppWidgetProvider() {
         fun updateWidget(context: Context, appWidgetId: Int, appWidgetManager: AppWidgetManager) {
             val userStorage = MonzoWidgetApp.get(context).storageModule.userStorage
             val accountType = userStorage.getAccountType(appWidgetId)
-            val isCurrentAccount = accountType == SettingsPresenter.AccountType.CURRENT.ordinal
+            val isCurrentAccount = accountType == AccountType.CURRENT_ACCOUNT.ordinal
 
             val accountBalance = (if (isCurrentAccount)
                 userStorage.currentAccountBalance

--- a/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsActivity.kt
@@ -5,16 +5,34 @@ import android.appwidget.AppWidgetManager
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import com.emmaguy.monzo.widget.MonzoWidgetApp
 import com.emmaguy.monzo.widget.R
+import com.jakewharton.rxbinding2.view.clicks
+import com.jakewharton.rxbinding2.view.enabled
+import io.reactivex.Observable
+import kotlinx.android.synthetic.main.activity_settings.*
 
 
-class SettingsActivity : AppCompatActivity() {
+class SettingsActivity : AppCompatActivity(), SettingsPresenter.View {
+
+    private val presenter by lazy { MonzoWidgetApp.get(this).settingsModule.provideSettingsPresenter() }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_settings)
 
-        // TODO: test adding a widget directly choosing between prepaid/current account
+        setResult(RESULT_CANCELED)
+
+        presenter.attachView(this)
+    }
+
+    override fun onDestroy() {
+        presenter.detachView()
+        super.onDestroy()
+    }
+
+    override fun finishSuccess() {
         val extras = intent.extras
         if (extras != null) {
             val widgetId = extras.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID)
@@ -24,5 +42,30 @@ class SettingsActivity : AppCompatActivity() {
             }
         }
     }
+
+    override fun finishActivity() {
+        finish()
+    }
+
+    override fun getSettingsIntent(): Intent {
+        return intent
+    }
+
+    override fun onCurrentAccountClicked(): Observable<Unit> {
+        return cButton.clicks()
+    }
+
+    override fun onPrepaidAccountClicked(): Observable<Unit> {
+        return ppButton.clicks()
+    }
+
+    override fun showCurrentAccountButton(enabled: Boolean) {
+        cButton.isEnabled = enabled
+    }
+
+    override fun showPrepaidAccountButton(enabled: Boolean) {
+        ppButton.isEnabled = enabled
+    }
+
 }
 

--- a/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsActivity.kt
@@ -8,7 +8,6 @@ import android.support.v7.app.AppCompatActivity
 import com.emmaguy.monzo.widget.MonzoWidgetApp
 import com.emmaguy.monzo.widget.R
 import com.jakewharton.rxbinding2.view.clicks
-import com.jakewharton.rxbinding2.view.enabled
 import io.reactivex.Observable
 import kotlinx.android.synthetic.main.activity_settings.*
 

--- a/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsModule.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsModule.kt
@@ -1,0 +1,14 @@
+package com.emmaguy.monzo.widget.settings
+
+import android.content.Context
+import com.emmaguy.monzo.widget.StorageModule
+
+class SettingsModule(
+        private val context: Context,
+        private val storageModule: StorageModule) {
+
+    fun provideSettingsPresenter(): SettingsPresenter {
+        return SettingsPresenter(context, storageModule.userStorage)
+    }
+
+}

--- a/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsPresenter.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsPresenter.kt
@@ -8,6 +8,7 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import com.emmaguy.monzo.widget.balance.BalanceWidgetProvider
 import android.content.Intent
+import com.emmaguy.monzo.widget.api.model.AccountType
 
 
 class SettingsPresenter(
@@ -38,7 +39,7 @@ class SettingsPresenter(
     }
 
     private fun currentAccountClick(onCurrentAccountClicked: Observable<Unit>): Disposable {
-        return onCurrentAccountClicked.subscribe({ accountTypeButtonClick(AccountType.CURRENT) })
+        return onCurrentAccountClicked.subscribe({ accountTypeButtonClick(AccountType.CURRENT_ACCOUNT) })
     }
 
     private fun accountTypeButtonClick(accountType: AccountType) {
@@ -66,10 +67,5 @@ class SettingsPresenter(
         fun showCurrentAccountButton(enabled: Boolean)
         fun showPrepaidAccountButton(enabled: Boolean)
         fun getSettingsIntent(): Intent
-    }
-
-    enum class AccountType {
-        PREPAID,
-        CURRENT
     }
 }

--- a/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsPresenter.kt
+++ b/app/src/main/java/com/emmaguy/monzo/widget/settings/SettingsPresenter.kt
@@ -1,0 +1,75 @@
+package com.emmaguy.monzo.widget.settings
+
+import com.emmaguy.monzo.widget.UserStorage
+import com.emmaguy.monzo.widget.common.BasePresenter
+import io.reactivex.Observable
+import io.reactivex.disposables.Disposable
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import com.emmaguy.monzo.widget.balance.BalanceWidgetProvider
+import android.content.Intent
+
+
+class SettingsPresenter(
+        private val context: Context,
+        private val userStorage: UserStorage
+) : BasePresenter<SettingsPresenter.View>() {
+
+    private lateinit var settingsView: SettingsPresenter.View
+
+    override fun attachView(view: SettingsPresenter.View) {
+        super.attachView(view)
+        settingsView = view
+
+        disposables.add(prepaidAccountClick(view.onPrepaidAccountClicked()))
+        disposables.add(currentAccountClick(view.onCurrentAccountClicked()))
+
+        enableButtons()
+    }
+
+    private fun enableButtons() {
+        // Disable account type button if it has no balance
+        settingsView.showCurrentAccountButton(userStorage.currentAccountBalance != null)
+        settingsView.showPrepaidAccountButton(userStorage.prepaidBalance != null)
+    }
+
+    private fun prepaidAccountClick(onPrepaidAccountClicked: Observable<Unit>): Disposable {
+        return onPrepaidAccountClicked.subscribe({ accountTypeButtonClick(AccountType.PREPAID) })
+    }
+
+    private fun currentAccountClick(onCurrentAccountClicked: Observable<Unit>): Disposable {
+        return onCurrentAccountClicked.subscribe({ accountTypeButtonClick(AccountType.CURRENT) })
+    }
+
+    private fun accountTypeButtonClick(accountType: AccountType) {
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+
+        val extras = settingsView.getSettingsIntent().extras
+        val widgetId = extras.getInt(
+                AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID)
+
+        if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            settingsView.finishActivity()
+        }
+
+        userStorage.saveAccountType(widgetId, accountType.ordinal)
+        BalanceWidgetProvider.updateWidget(context, widgetId, appWidgetManager)
+
+        settingsView.finishSuccess()
+    }
+
+    interface View : BasePresenter.View {
+        fun finishSuccess()
+        fun finishActivity()
+        fun onCurrentAccountClicked(): Observable<Unit>
+        fun onPrepaidAccountClicked(): Observable<Unit>
+        fun showCurrentAccountButton(enabled: Boolean)
+        fun showPrepaidAccountButton(enabled: Boolean)
+        fun getSettingsIntent(): Intent
+    }
+
+    enum class AccountType {
+        PREPAID,
+        CURRENT
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -6,16 +6,36 @@
                                              android:layout_height="match_parent"
                                              tools:context="com.emmaguy.monzo.widget.login.LoginActivity">
 
-    <TextView android:id="@+id/settingsTextView"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginEnd="16dp"
-              android:layout_marginStart="16dp"
-              android:gravity="center"
-              android:text="oh hai"
-              app:layout_constraintBottom_toBottomOf="parent"
-              app:layout_constraintLeft_toLeftOf="parent"
-              app:layout_constraintRight_toRightOf="parent"
-              app:layout_constraintTop_toTopOf="parent"/>
+    <Button
+        android:id="@+id/ppButton"
+        android:layout_width="157dp"
+        android:layout_height="wrap_content"
+        android:text="Pre-Paid Account"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginEnd="8dp"
+        app:layout_constraintHorizontal_bias="0.502"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/guideline" />
+
+    <Button
+        android:id="@+id/cButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Current Account"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginEnd="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="8dp"
+        app:layout_constraintTop_toTopOf="@+id/guideline"
+        android:layout_marginTop="8dp" />
+
+    <android.support.constraint.Guideline
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintGuide_percent="0.5"
+        android:orientation="horizontal"
+        android:id="@+id/guideline" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/widget_balance.xml
+++ b/app/src/main/res/layout/widget_balance.xml
@@ -1,23 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <TextView android:id="@+id/widgetBackgroundView"
-              android:layout_width="56dp"
-              android:layout_height="56dp"
-              android:layout_centerHorizontal="true"
-              android:layout_marginTop="4dp"/>
+    <TextView
+        android:id="@+id/widgetBackgroundView"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="4dp" />
 
-    <TextView android:id="@+id/widgetAmountTextView"
-              android:layout_width="wrap_content"
-              android:layout_height="match_parent"
-              android:layout_alignBottom="@id/widgetBackgroundView"
-              android:layout_alignTop="@id/widgetBackgroundView"
-              android:layout_centerInParent="true"
-              android:gravity="center"
-              android:maxLines="1"
-              tools:text="12"/>
+    <TextView
+        android:id="@+id/widgetAmountTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignBottom="@id/widgetBackgroundView"
+        android:layout_alignTop="@id/widgetBackgroundView"
+        android:layout_centerInParent="true"
+        android:gravity="center"
+        android:maxLines="1"
+        tools:text="12" />
 
 </RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha8'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha9'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jul 16 16:58:36 BST 2017
+#Sat Aug 05 12:25:07 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip


### PR DESCRIPTION
This pull request aims to resolve #1. It also sort of helps with issue #3 but still not ideal.

Now when adding an instance of the widget, the `SettingsActivity` is displayed to allow an account type to be chosen. If a balance for one of the account types is not available (is null) the corresponding button is disabled, not allowing the user to choose that account type and add a widget of that type.

Clicking a widget starts the `SettingsActivity` and allows changing the account type of the current widget.

When adding a widget for the first time without logging in, no account type can be chosen in the `SettingsActivity` because no balances are available therefore forcing the user to close the activity which does not then add the widget. 